### PR TITLE
Allow the PWA to run in landscape

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
   ],
   "start_url": "index.html",
   "display": "standalone",
-  "orientation": "portrait",
+  "orientation": "any",
   "background_color": "#253352",
   "theme_color": "#253352"
 }


### PR DESCRIPTION
On Android (this might also be the case on iOS, I can't confirm), the PWA is forced to portrait thanks to the original manifest commit. This is pretty much a small fix that still allows portrait use for those that want that.